### PR TITLE
improve compatibility to plugin manager and fix large-file rendering issues

### DIFF
--- a/markdown-preview.vim
+++ b/markdown-preview.vim
@@ -1,57 +1,72 @@
 " ========== Simple Markdown Preview Plugin ==========
 
-function! ToggleMarkdownPreview()
-  " Check if preview window exists
+function! s:PreviewWinnr()
   for winnr in range(1, winnr('$'))
     if getwinvar(winnr, 'is_markdown_preview', 0)
-      " Found preview window, close it and return to source
-      let l:source_winnr = getwinvar(winnr, 'source_winnr', 0)
-      execute winnr . 'wincmd w'
-      
-      " Force close the window and its buffer
-      quit!
-      
-      " Return to source window if it exists
-      if l:source_winnr > 0 && l:source_winnr <= winnr('$')
-        execute l:source_winnr . 'wincmd w'
-      endif
-      return
+      return winnr
     endif
   endfor
-  
+  return 0
+endfunction
+
+function! s:ScrollToTop(timer_id)
+  let l:winnr = s:PreviewWinnr()
+  if l:winnr > 0
+    let l:cur = winnr()
+    execute l:winnr . 'wincmd w'
+    normal! gg
+    execute l:cur . 'wincmd w'
+  endif
+endfunction
+
+function! s:OnGlowFinish(temp_file, job, status)
+  call timer_start(50, function('s:ScrollToTop'))
+  call delete(a:temp_file)
+endfunction
+
+function! ToggleMarkdownPreview()
+  let l:winnr = s:PreviewWinnr()
+  if l:winnr > 0
+    " Found preview window, close it and return to source
+    let l:source_winnr = getwinvar(l:winnr, 'source_winnr', 0)
+    execute l:winnr . 'wincmd w'
+    quit!
+    if l:source_winnr > 0 && l:source_winnr <= winnr('$')
+      execute l:source_winnr . 'wincmd w'
+    endif
+    return
+  endif
+
   " No preview found, create one
   let l:source_winnr = winnr()
   let l:width = float2nr(&columns * 0.5)
-  
+
   if executable('glow') && has('terminal')
-    " Create terminal directly with glow
+    " Read content before switching windows, then open vertical split
     let l:temp_file = tempname() . '.md'
     let l:content = getline(1, '$')
     call writefile(l:content, l:temp_file)
-    
-    execute 'rightbelow vertical terminal glow -s dark -w ' . (l:width - 4) . ' ' . l:temp_file
+    execute 'rightbelow vnew'
     execute 'vertical resize ' . l:width
-    
-    " Position cursor at top after glow completes rendering
-    call timer_start(500, {-> feedkeys("\<C-\>\<C-n>gg")})
-    
-    " Clean up temp file after delay
-    call timer_start(2000, {-> delete(l:temp_file)})
+    call term_start(['glow', '-s', 'dark', l:temp_file], {
+      \ 'curwin': 1,
+      \ 'exit_cb': function('s:OnGlowFinish', [l:temp_file]),
+      \ })
   else
     " Basic fallback - create buffer with content directly
     execute 'rightbelow vnew'
     execute 'vertical resize ' . l:width
-    
+
     setlocal buftype=nofile noswapfile nobuflisted
     let l:content = getbufline('#', 1, '$')
     call setline(1, l:content)
     setlocal ft=markdown readonly nomodifiable
   endif
-  
+
   " Mark this window as preview and store source
   let w:is_markdown_preview = 1
   let w:source_winnr = l:source_winnr
-  
+
   " Simple quit mapping - just close window and return to source
   nnoremap <buffer> q :call ToggleMarkdownPreview()<CR>
   if has('terminal') && &buftype == 'terminal'
@@ -61,15 +76,13 @@ endfunction
 
 " Auto-resize preview when window is resized
 function! ResizeMarkdownPreview()
-  for winnr in range(1, winnr('$'))
-    if getwinvar(winnr, 'is_markdown_preview', 0)
-      let l:width = float2nr(&columns * 0.5)
-      execute winnr . 'wincmd w'
-      execute 'vertical resize ' . l:width
-      execute 'wincmd p'
-      return
-    endif
-  endfor
+  let l:winnr = s:PreviewWinnr()
+  if l:winnr > 0
+    let l:width = float2nr(&columns * 0.5)
+    execute l:winnr . 'wincmd w'
+    execute 'vertical resize ' . l:width
+    execute 'wincmd p'
+  endif
 endfunction
 
 " Set up auto-resize

--- a/plugin/markdown-preview.vim
+++ b/plugin/markdown-preview.vim
@@ -1,0 +1,1 @@
+../markdown-preview.vim


### PR DESCRIPTION
  **Summary**

1. Add a `plugin/` directory with a symlink to `markdown-preview.vim`, enabling automatic plugin loading for Vim plugin managers that follow the standard runtime path structure.
2.  Fix Truncated rendering and Double line-wrapping when previewing large-file: wait for glow to finish before scrolling and drop the `-w` flag entirely and let glow auto-detect terminal width.
